### PR TITLE
Fix type for blog page props

### DIFF
--- a/src/app/blog/[id]/page.tsx
+++ b/src/app/blog/[id]/page.tsx
@@ -9,7 +9,13 @@ export const metadata: Metadata = {
   description: "Detailed information about our research projects",
 };
 
-export default function BlogDetails({ params }: { params: { id: string } }) {
+interface BlogDetailsProps {
+  params: {
+    id: string;
+  };
+}
+
+export default function BlogDetails({ params }: BlogDetailsProps) {
   const blog = blogData.find((blog) => blog.id === parseInt(params.id));
 
   if (!blog) {


### PR DESCRIPTION
## Summary
- update blog detail page to use a simpler local props interface

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*
